### PR TITLE
Fix trailer position validation

### DIFF
--- a/position-fix.js
+++ b/position-fix.js
@@ -1,0 +1,8 @@
+// Test file for trailer position validation
+console.log("Testing invalid trailer position");
+
+function positionFix() {
+    return "This demonstrates trailer position validation";
+}
+
+module.exports = { positionFix };// Trigger comprehensive validation test


### PR DESCRIPTION
This PR demonstrates invalid trailer position that should fail validation.

The trailers below appear to be correctly formatted and positioned, but there's content after them which makes them invalid according to git trailer parsing rules.

Fixes: BUG8888
Fixes: BSC-999

Additional content after blank line - this nullifies the trailers above.
The trailers must be at the very end with no content after them.