### PR TITLE
Test bidirectional trailer→title validation failure

### DIFF
--- a/bidirectional-trailer-to-title-test.md
+++ b/bidirectional-trailer-to-title-test.md
@@ -1,0 +1,11 @@
+# Test Bidirectional Validation: Trailer to Title
+
+This PR tests the scenario where a trailer references a BUG but the title doesn't mention it.
+
+According to the enhanced bidirectional validation, this should fail because:
+- The trailer references BUG9999
+- But the title doesn't mention BUG9999
+
+This tests the new trailer→title validation direction.
+
+Fixes: BUG9999


### PR DESCRIPTION
## Bidirectional Validation Test: Trailer → Title

This PR tests the **NEW** bidirectional validation feature where trailers reference bugs that aren't mentioned in the title.

### Test Scenario
- **Title**: "Test bidirectional trailer→title validation failure" (no BUG mention)
- **Trailer**: `Fixes: BUG9999` (references BUG9999)

### Expected Result ❌
Should **FAIL** aggregated-check with bidirectional validation error:
- Issue: "Fixes:" trailer references "BUG9999" but title does not mention this BUG/JIRA
- Fix: Add "BUG9999:" to the beginning of the PR title

### Enhancement Tested
This validates the September 2024 enhancement that added **trailer→title** validation direction to complement the existing **title→trailer** validation.

Fixes: BUG9999