### PR TITLE
BUG8888: Test bidirectional title/trailer mismatch

### DIFF
--- a/bidirectional-mismatch-test.md
+++ b/bidirectional-mismatch-test.md
@@ -1,0 +1,11 @@
+# Test Bidirectional Validation: Title/Trailer Mismatch
+
+This PR tests the scenario where title and trailer reference different bugs.
+
+According to the enhanced bidirectional validation, this should fail because:
+- The title mentions BUG8888
+- But the trailer references BUG7777
+
+This tests both validation directions simultaneously.
+
+Fixes: BUG7777


### PR DESCRIPTION
## Bidirectional Validation Test: Title/Trailer Mismatch

This PR tests the **bidirectional validation** feature where title and trailer reference different bugs.

### Test Scenario
- **Title**: "BUG8888: Test bidirectional title/trailer mismatch" (mentions BUG8888)
- **Trailer**: `Fixes: BUG7777` (references BUG7777)

### Expected Result ❌
Should **FAIL** aggregated-check with **BOTH** bidirectional validation errors:
1. **Title→Trailer**: BUG/JIRA reference "BUG8888" in title missing corresponding "Fixes:" trailer
2. **Trailer→Title**: "Fixes:" trailer references "BUG7777" but title does not mention this BUG/JIRA

### Enhancement Tested
This validates the September 2024 enhancement that added comprehensive bidirectional validation checking both directions simultaneously.

Fixes: BUG7777