### PR TITLE
BUG1111, BSC-222, ATLAS-333: Test multiple bugs with partial trailer

### DIFF
--- a/multiple-bugs-partial-trailer.md
+++ b/multiple-bugs-partial-trailer.md
@@ -1,0 +1,12 @@
+# Test Multiple Bugs: Partial Trailer Coverage
+
+This PR tests bidirectional validation with multiple bugs where some are missing from the trailer.
+
+According to the enhanced bidirectional validation, this should fail because:
+- The title mentions BUG1111, BSC-222, and ATLAS-333
+- But the trailer only references BUG1111 and BSC-222
+- Missing ATLAS-333 in the trailer
+
+This tests multiple bug handling in bidirectional validation.
+
+Fixes: BUG1111 BSC-222


### PR DESCRIPTION
## Multiple Bugs Test: Partial Trailer Coverage ❌

This PR tests **bidirectional validation** with multiple bugs where some are missing from trailers.

### Test Scenario
- **Title**: "BUG1111, BSC-222, ATLAS-333: Test multiple bugs with partial trailer"
  - References: BUG1111, BSC-222, ATLAS-333
- **Trailer**: `Fixes: BUG1111 BSC-222`
  - References: BUG1111, BSC-222 (missing ATLAS-333)

### Expected Result ❌
Should **FAIL** aggregated-check with bidirectional validation error:
- **Title→Trailer**: BUG/JIRA reference "ATLAS-333" in title missing corresponding "Fixes:" trailer
- **Fix**: Add "Fixes: ATLAS-333" as a trailer at the end of the PR description

### Enhancement Tested
This validates that bidirectional validation correctly handles **multiple bug references** and identifies missing trailer coverage for each individual bug.

Fixes: BUG1111 BSC-222