### PR TITLE
BSC-444: Test multiple bugs with partial title coverage

### DIFF
--- a/multiple-bugs-partial-title.md
+++ b/multiple-bugs-partial-title.md
@@ -1,0 +1,12 @@
+# Test Multiple Bugs: Partial Title Coverage
+
+This PR tests bidirectional validation with multiple bugs where some are missing from the title.
+
+According to the enhanced bidirectional validation, this should fail because:
+- The title only mentions BSC-444
+- But the trailer references BSC-444, ATLAS-555, and BUG2222
+- Missing ATLAS-555 and BUG2222 in the title
+
+This tests trailer→title validation with multiple bugs.
+
+Fixes: BSC-444 ATLAS-555 BUG2222


### PR DESCRIPTION
## Multiple Bugs Test: Partial Title Coverage ❌

This PR tests **bidirectional validation** with multiple bugs where some are missing from the title.

### Test Scenario
- **Title**: "BSC-444: Test multiple bugs with partial title coverage"
  - References: BSC-444 only
- **Trailer**: `Fixes: BSC-444 ATLAS-555 BUG2222`
  - References: BSC-444, ATLAS-555, BUG2222

### Expected Result ❌
Should **FAIL** aggregated-check with bidirectional validation errors:
- **Trailer→Title**: "Fixes:" trailer references "ATLAS-555" but title does not mention this BUG/JIRA
- **Trailer→Title**: "Fixes:" trailer references "BUG2222" but title does not mention this BUG/JIRA
- **Fix**: Add "ATLAS-555:" and "BUG2222:" to the beginning of the PR title

### Enhancement Tested
This validates that bidirectional validation correctly handles **multiple bug references** and identifies missing title coverage for each individual bug.

Fixes: BSC-444 ATLAS-555 BUG2222