### PR TITLE
BUG3333, BSC-777: Test multiple bugs complete mismatch

### DIFF
--- a/multiple-bugs-complete-mismatch.md
+++ b/multiple-bugs-complete-mismatch.md
@@ -1,0 +1,12 @@
+# Test Multiple Bugs: Complete Mismatch
+
+This PR tests bidirectional validation with completely different sets of bugs.
+
+According to the enhanced bidirectional validation, this should fail because:
+- The title mentions BUG3333 and BSC-777
+- But the trailer references ATLAS-888 and BUG4444
+- No bugs match between title and trailer
+
+This tests complete mismatch scenarios with multiple bugs.
+
+Fixes: ATLAS-888 BUG4444


### PR DESCRIPTION
## Multiple Bugs Test: Complete Mismatch ❌

This PR tests **bidirectional validation** with completely different sets of bugs in title vs trailer.

### Test Scenario
- **Title**: "BUG3333, BSC-777: Test multiple bugs complete mismatch"
  - References: BUG3333, BSC-777
- **Trailer**: `Fixes: ATLAS-888 BUG4444`
  - References: ATLAS-888, BUG4444

### Expected Result ❌
Should **FAIL** aggregated-check with **MULTIPLE** bidirectional validation errors:

**Title→Trailer** (missing trailers):
- BUG/JIRA reference "BUG3333" in title missing corresponding "Fixes:" trailer
- BUG/JIRA reference "BSC-777" in title missing corresponding "Fixes:" trailer

**Trailer→Title** (missing in title):
- "Fixes:" trailer references "ATLAS-888" but title does not mention this BUG/JIRA
- "Fixes:" trailer references "BUG4444" but title does not mention this BUG/JIRA

### Enhancement Tested
This validates that bidirectional validation correctly handles **complete mismatches** between title and trailer bug references.

Fixes: ATLAS-888 BUG4444