### PR TITLE
BUG1010, BSC-202, ATLAS-303: Test multiple Fixes lines valid

### DIFF
--- a/multiple-fixes-lines-valid.md
+++ b/multiple-fixes-lines-valid.md
@@ -1,0 +1,14 @@
+# Test Multiple Fixes Lines: Valid Match
+
+This PR tests bidirectional validation with multiple Fixes lines that properly match the title.
+
+According to the enhanced bidirectional validation, this should pass because:
+- The title mentions BUG1010, BSC-202, and ATLAS-303
+- Each bug has its own Fixes line
+- All bugs match between title and trailer in both directions
+
+This tests successful bidirectional validation with multiple Fixes lines format.
+
+Fixes: BUG1010
+Fixes: BSC-202
+Fixes: ATLAS-303


### PR DESCRIPTION
## Multiple Fixes Lines Test: Valid Match ✅

This PR tests **bidirectional validation** with multiple `Fixes:` lines that properly match the title.

### Test Scenario
- **Title**: "BUG1010, BSC-202, ATLAS-303: Test multiple Fixes lines valid"
  - References: BUG1010, BSC-202, ATLAS-303 (comma-separated)
- **Trailers**: Multiple separate Fixes lines:

### Expected Result ✅
Should **PASS** aggregated-check with successful bidirectional validation:

**Title→Trailer** ✓:
- BUG1010 in title has corresponding "Fixes: BUG1010" trailer
- BSC-202 in title has corresponding "Fixes: BSC-202" trailer  
- ATLAS-303 in title has corresponding "Fixes: ATLAS-303" trailer

**Trailer→Title** ✓:
- Each "Fixes:" trailer matches bugs mentioned in title

### Enhancement Tested
This validates that bidirectional validation correctly handles **multiple Fixes lines format** as documented in the MRFT trailer validation spec.

Fixes: BUG1010
Fixes: BSC-202
Fixes: ATLAS-303