### PR TITLE
BUG1515, BSC-404, ATLAS-505: Test multiple Fixes lines partial

### DIFF
--- a/multiple-fixes-lines-partial.md
+++ b/multiple-fixes-lines-partial.md
@@ -1,0 +1,13 @@
+# Test Multiple Fixes Lines: Partial Match
+
+This PR tests bidirectional validation with multiple Fixes lines where some bugs are missing.
+
+According to the enhanced bidirectional validation, this should fail because:
+- The title mentions BUG1515, BSC-404, and ATLAS-505
+- But only BUG1515 and BSC-404 have Fixes lines
+- Missing ATLAS-505 Fixes line
+
+This tests partial coverage with multiple Fixes lines format.
+
+Fixes: BUG1515
+Fixes: BSC-404


### PR DESCRIPTION
## Multiple Fixes Lines Test: Partial Coverage ❌

This PR tests **bidirectional validation** with multiple `Fixes:` lines where some bugs are missing.

### Test Scenario
- **Title**: "BUG1515, BSC-404, ATLAS-505: Test multiple Fixes lines partial"
  - References: BUG1515, BSC-404, ATLAS-505. 
- **Trailers**: Only partial Fixes lines:

  - Missing: `Fixes: ATLAS-505`

### Expected Result ❌
Should **FAIL** aggregated-check with bidirectional validation error:
- **Title→Trailer**: BUG/JIRA reference "ATLAS-505" in title missing corresponding "Fixes:" trailer
- **Fix**: Add "Fixes: ATLAS-505" as a trailer at the end of the PR description

### Enhancement Tested
This validates that bidirectional validation correctly detects **missing Fixes lines** when using the multiple lines format.

Fixes: BUG1515
Fixes: BSC-404