### PR TITLE
BUG2020 BSC-606 ATLAS-707: Test title space separation valid

### DIFF
--- a/title-space-separation-valid.md
+++ b/title-space-separation-valid.md
@@ -1,0 +1,12 @@
+# Test Title Space Separation: Valid Match
+
+This PR tests bidirectional validation with space-only separation in title (no commas).
+
+According to the enhanced bidirectional validation, this should pass because:
+- The title uses space separation: BUG2020 BSC-606 ATLAS-707
+- All bugs have corresponding Fixes trailers
+- Both directions validate correctly
+
+This tests title format flexibility with space-only separation.
+
+Fixes: BUG2020 BSC-606 ATLAS-707


### PR DESCRIPTION
## Title Format Test: Space Separation Valid ✅

This PR tests **bidirectional validation** with space-only separation in title (no commas).

### Test Scenario
- **Title**: "BUG2020 BSC-606 ATLAS-707: Test title space separation valid"
  - References: BUG2020, BSC-606, ATLAS-707 (space-separated, no commas)
- **Trailer**: `Fixes: BUG2020 BSC-606 ATLAS-707`
  - References: BUG2020, BSC-606, ATLAS-707

### Expected Result ✅
Should **PASS** aggregated-check with successful bidirectional validation:

**Title→Trailer** ✓:
- BUG2020 in title has corresponding "Fixes: BUG2020" trailer
- BSC-606 in title has corresponding "Fixes: BSC-606" trailer  
- ATLAS-707 in title has corresponding "Fixes: ATLAS-707" trailer

**Trailer→Title** ✓:
- All trailer references match bugs mentioned in title

### Enhancement Tested
This validates that bidirectional validation correctly handles **space-only separation** in titles without requiring commas, as mentioned in your requirements.

Fixes: BUG2020 BSC-606  ATLAS-707