### PR TITLE
BUG3030 BSC-808 ATLAS-909: Test title space separation partial

### DIFF
--- a/title-space-separation-partial.md
+++ b/title-space-separation-partial.md
@@ -1,0 +1,12 @@
+# Test Title Space Separation: Partial Coverage
+
+This PR tests bidirectional validation with space-only separation in title where some trailers are missing.
+
+According to the enhanced bidirectional validation, this should fail because:
+- The title uses space separation: BUG3030 BSC-808 ATLAS-909
+- But trailer only references BUG3030 and BSC-808
+- Missing ATLAS-909 in the trailer
+
+This tests title format flexibility with missing trailer coverage.
+
+Fixes: BUG3030 BSC-808


### PR DESCRIPTION
## Title Format Test: Space Separation Partial ❌

This PR tests **bidirectional validation** with space-only separation in title where some trailers are missing.

### Test Scenario
- **Title**: "BUG3030 BSC-808 ATLAS-909: Test title space separation partial"
  - References: BUG3030, BSC-808, ATLAS-909 (space-separated, no commas)
- **Trailer**: `Fixes: BUG3030 BSC-808`.  
  - References: BUG3030, BSC-808 (missing ATLAS-909)

### Expected Result ❌
Should **FAIL** aggregated-check with bidirectional validation error:
- **Title→Trailer**: BUG/JIRA reference "ATLAS-909" in title missing corresponding "Fixes:" trailer
- **Fix**: Add "Fixes: ATLAS-909" as a trailer at the end of the PR description

### Enhancement Tested
This validates that bidirectional validation correctly handles **space-only separation** in titles and properly detects missing trailer coverage.

Fixes: BUG3030 BSC-808