### PR TITLE
BUG9876: Test MRFT status transition behavior

### DIFF
--- a/.github/workflows/long-running-test.yml
+++ b/.github/workflows/long-running-test.yml
@@ -1,0 +1,44 @@
+name: Long Running Test
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  long-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Initial step
+      run: |
+        echo "Starting long-running test..."
+        echo "This test will run for 5 minutes to test MRFT status transitions"
+        date
+
+    - name: Wait 2 minutes
+      run: |
+        echo "Waiting 2 minutes..."
+        sleep 120
+        echo "2 minutes completed at $(date)"
+
+    - name: Mid-test checkpoint
+      run: |
+        echo "Mid-test checkpoint at $(date)"
+        echo "Test is halfway through..."
+
+    - name: Wait another 2 minutes
+      run: |
+        echo "Waiting another 2 minutes..."
+        sleep 120
+        echo "4 minutes total completed at $(date)"
+
+    - name: Final step
+      run: |
+        echo "Waiting final minute..."
+        sleep 60
+        echo "Long-running test completed successfully at $(date)"
+        echo "Total test duration: ~5 minutes"

--- a/mrft-status-transition-test.md
+++ b/mrft-status-transition-test.md
@@ -1,0 +1,13 @@
+# Test MRFT Status Transition
+
+This PR tests the behavior when MRFT validation changes from invalid to valid.
+
+Initial state: This PR will start with INVALID MRFT trailers.
+Expected: aggregated-check should fail immediately.
+
+Then we'll edit to fix the MRFT validation.
+Expected: aggregated-check should go back to pending and re-evaluate.
+
+This tests the automatic status change detection and reprocessing logic.
+
+Fixes: [BUG9876](https://bb/9876)


### PR DESCRIPTION
## 🧪 MRFT Status Transition Test

This PR tests the **automatic status change detection** when MRFT validation changes from invalid → valid.

### Phase 1: Invalid MRFT ❌ (COMPLETED)
**Initial PR state had INVALID MRFT trailer:**
- Description contained: `Fixes: [BUG9876](https://bb/9876)` (Markdown link)
- **Result**: Should trigger aggregated-check failure

### Phase 2: Fixed MRFT → Valid ✅ (CURRENT)
**Now edited to VALID MRFT trailer:**
- Changed to: `Fixes: BUG9876` (plain text)
- **Expected Result**: aggregated-check should go to **PENDING/IN_PROGRESS** and re-evaluate

### Testing Hypothesis
The webhook logic should detect MRFT validation status change and trigger immediate reprocessing within 1-2 seconds.

---

**🎉 Current State**: VALID MRFT - should pass validation

Fixes: BUG9876