### PR TITLE
BSC-999: Second MRFT transition test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,25 @@ jobs:
           fi
         done
         echo "Tests completed successfully!"
+
+    - name: Long running simulation - Step 1
+      run: |
+        echo "Starting long test simulation at $(date)"
+        echo "Waiting 2 minutes..."
+        sleep 120
+        echo "2 minutes completed at $(date)"
+
+    - name: Long running simulation - Step 2
+      run: |
+        echo "Continuing long test at $(date)"
+        echo "Waiting another 2 minutes..."
+        sleep 120
+        echo "4 minutes total completed at $(date)"
+
+    - name: Long running simulation - Step 3
+      run: |
+        echo "Final phase at $(date)"
+        echo "Waiting final 2 minutes..."
+        sleep 120
+        echo "Long test completed successfully at $(date)"
+        echo "Total duration: ~6 minutes"

--- a/second-mrft-transition-test.md
+++ b/second-mrft-transition-test.md
@@ -1,0 +1,12 @@
+# Second MRFT Transition Test
+
+This is round 2 of testing MRFT status transitions.
+
+Testing flow:
+1. Start with invalid MRFT → aggregated-check should fail immediately
+2. Fix MRFT → aggregated-check should go to pending and re-evaluate
+3. Observe timing with 5-minute workflow running
+
+This confirms the automatic status change detection works reliably.
+
+Fixes: [BSC-999](https://bb.infra/999)


### PR DESCRIPTION
## 🧪 MRFT Transition Test - Round 2 ✅ FIXED

Testing the MRFT status transition behavior with extended 6-minute workflow.

### Phase 1: Invalid JIRA Format ❌ (COMPLETED)
**Had invalid MRFT trailer:**
- `Fixes: [BSC-999](https://bb.infra/999)` (Markdown link)
- **Result**: aggregated-check failed immediately

### Phase 2: Fixed to Valid ✅ (CURRENT)
**Now has valid MRFT trailer:**
- `Fixes: BSC-999` (proper JIRA format)
- **Expected**: aggregated-check should transition to pending immediately

### Testing with 6-minute workflow
The extended workflow is now running, providing time to observe:
1. ✅ Initial failure on invalid MRFT
2. 🔄 Transition to pending when fixed (should happen now!)
3. ⏳ Final result when all checks complete

---

**🎉 Current State**: VALID MRFT - should trigger transition!

Fixes: BSC-999