### PR TITLE
TEST: Format validation specificity (only Fixes trailers)

### DIFF
--- a/format-specificity-test.md
+++ b/format-specificity-test.md
@@ -1,0 +1,1 @@
+Test format validation specificity


### PR DESCRIPTION
Fix issue with proper format validation

This tests that only Fixes trailers are validated for MRFT format, while other trailers can use any format including Markdown links.

smoke-test: --add [something](https://example.com)
Co-authored-by: [John Doe](mailto:john@example.com) 
Reviewed-by: See [team page](https://internal.example.com/team)
Fixes: [BUG123456](https://bb/123456)