### PR TITLE
TEST: Empty/whitespace-only trailer values

### DIFF
--- a/empty-trailer-test.md
+++ b/empty-trailer-test.md
@@ -1,0 +1,1 @@
+Test empty trailer values


### PR DESCRIPTION
Fix issue with empty trailer validation

This tests validation of empty and whitespace-only trailer values.

Fixes:   