### PR TITLE
BUG1234567: Test leading space in Git trailer (should fail MRFT validation)

### DIFF
--- a/leading-space-trailer.md
+++ b/leading-space-trailer.md
@@ -1,0 +1,5 @@
+# Leading Space Trailer Test
+
+This file demonstrates the Git trailer parsing edge case where a leading space prevents Git from recognizing the trailer.
+
+The key issue is that Git's trailer parsing is strict about formatting.


### PR DESCRIPTION
This PR tests the Git trailer parsing edge case where a leading space prevents trailer recognition.

Git trailer parsing rules:
- Leading spaces before the token make it invalid
- Only properly formatted trailers are recognized

Expected behavior:
- MRFT validator should detect the leading space issue  
- Aggregated check should fail with helpful error message
- Suggestion should be provided to fix the formatting

 Fixes: BUG1234567 