### PR TITLE
BUG1234567: Test blank lines in trailer block (should fail MRFT validation)

### DIFF
--- a/blank-lines-in-trailers.md
+++ b/blank-lines-in-trailers.md
@@ -1,0 +1,7 @@
+# Blank Lines in Trailer Block Test
+
+This file demonstrates the Git trailer parsing edge case where blank lines within a trailer block break continuity.
+
+According to Git trailer parsing rules, blank lines break the trailer block, causing subsequent trailer-like content to not be recognized as trailers.
+
+This affects MRFT parsing and should be detected by our validator.


### PR DESCRIPTION
This PR tests the Git trailer parsing edge case where blank lines break trailer block continuity.

Git trailer parsing rules:
- Blank lines within a trailer block break continuity
- Only trailers before the first blank line are recognized
- Content after blank lines is not part of the trailer block

Expected behavior:
- MRFT validator should detect the trailer block discontinuity
- Aggregated check should fail with position error
- Should suggest removing blank lines for continuous trailer block

Fixes: BUG1234567

Change-ID: abc123def456
Co-authored-by: Test User <test@example.com>