### PR TITLE
BUG123: Test Draft PR with MRFT errors

### DIFF
--- a/blank-lines-in-trailers.md
+++ b/blank-lines-in-trailers.md
@@ -1,0 +1,7 @@
+# Blank Lines in Trailer Block Test
+
+This file demonstrates the Git trailer parsing edge case where blank lines within a trailer block break continuity.
+
+According to Git trailer parsing rules, blank lines break the trailer block, causing subsequent trailer-like content to not be recognized as trailers.
+
+This affects MRFT parsing and should be detected by our validator.

--- a/draft-test.md
+++ b/draft-test.md
@@ -1,0 +1,1 @@
+This is a test file for draft PR with MRFT errors


### PR DESCRIPTION
This is a draft PR to test MRFT validation skipping.

This PR contains malformed MRFT trailers that would normally fail validation.
Since this is a draft PR, the aggregated-check should show PASS.

Fixes: [BUG123](https://bugzilla.example.com/123)
Fixes: <a href="https://jira.example.com">BSC-456</a>