### PR TITLE
ATLAS-456: Test Do Not Merge label skips MRFT validation

### DIFF
--- a/do-not-merge-test.md
+++ b/do-not-merge-test.md
@@ -1,0 +1,1 @@
+This is a test file for Do Not Merge label behavior


### PR DESCRIPTION
This PR tests that 'Do Not Merge' label skips MRFT validation.

**Expected behavior:**
- With malformed MRFT trailers below
- But with 'Do Not Merge' label
- Should show aggregated-check PASS (MRFT validation skipped)

Contains malformed MRFT trailers that would normally fail:

Fixes: [ATLAS-456](https://jira.example.com/ATLAS-456)
Fixes: <script>alert('xss')</script>
Fixes: bug-invalid-format