### PR TITLE
[DMF-123] FOO-1.2.3 BUG456: Test bracket interference fix

### DIFF
--- a/branch-pattern-test.md
+++ b/branch-pattern-test.md
@@ -1,0 +1,12 @@
+# Branch Reference Pattern Intelligence Test
+
+This test checks that JIRA-like patterns in square brackets are ignored.
+
+The enhanced pattern filtering should NOT trigger MRFT errors for patterns like:
+- [DMF-8.9.x] (version branch pattern)
+- [FOO-1.2.3] (version pattern)
+- [ATLAS-1.0] (release pattern)
+
+This content should pass MRFT validation without errors.
+
+Fixes: TEST123

--- a/branch-reference-test.md
+++ b/branch-reference-test.md
@@ -1,0 +1,16 @@
+# Branch Reference Pattern Intelligence Test
+
+This test verifies that JIRA-like patterns in square brackets are properly ignored and don't trigger false MRFT validation errors.
+
+The enhanced branch reference intelligence should ignore patterns like:
+- [DMF-8.9.x]
+- [FOO-1.2.3]
+- [ATLAS-1.0]
+
+But should still detect actual JIRA references like:
+- DMF-123: (without brackets)
+- BSC-456: (without brackets)
+
+This PR tests the enhanced pattern filtering.
+
+Fixes: BUG999888

--- a/enhanced-error-specific-line-test.md
+++ b/enhanced-error-specific-line-test.md
@@ -1,0 +1,11 @@
+# Enhanced Error Messaging - Specific Line Detection Test
+
+This test should trigger enhanced error messages pointing to specific problematic lines.
+
+## Test Case 1: Trailer separation issue
+
+This PR addresses multiple authentication issues.
+cc: @reviewer-name
+another-field: some value
+
+Fixes: BUG123456

--- a/enhanced-error-test.md
+++ b/enhanced-error-test.md
@@ -1,0 +1,11 @@
+# Enhanced Error Messaging Test
+
+This PR tests the enhanced MRFT validation error messaging that should now point to specific problematic lines.
+
+This PR addresses authentication issues and adds new features based on user feedback.
+
+Reviewer: trivial
+Cherry picks master PR: https://github.com/bigswitch/bigtap/pull/10826
+cc: @jfell-arista
+
+Fixes: BT-16390

--- a/long-running-test.md
+++ b/long-running-test.md
@@ -12,3 +12,12 @@ Test trigger content:
 - Performance benchmarks  
 - Extended validation suite
 
+
+
+## 🕒 Workflow Update - 4-minute timing test now active!
+
+The GitHub workflow with 4-minute extended test is now enabled.
+This update will trigger the timing test to demonstrate MRFT skip behavior.
+
+Updated at: Mon Sep 29 17:31:09 PDT 2025
+

--- a/long-running-test.md
+++ b/long-running-test.md
@@ -1,0 +1,14 @@
+# Long-running test with Do Not Merge label
+
+This file will trigger a long-running test to demonstrate MRFT validation skip behavior.
+
+The test should take ~5 minutes to complete, during which time:
+1. MRFT validation should be SKIPPED (due to Do Not Merge label)
+2. Aggregated check should show IN_PROGRESS (waiting for test)
+3. After 5 minutes, should show FAIL due to Do Not Merge label only
+
+Test trigger content:
+- Long integration test
+- Performance benchmarks  
+- Extended validation suite
+


### PR DESCRIPTION
# Bracket Interference Fix Test

This PR tests the fix for the bracket interference bug.

**Title contains:**
- DMF-123 - should be detected as JIRA reference requiring trailer
- [FOO-1.2.3] - should be ignored (bracket-wrapped)
- BUG456 - should be detected as BUG reference

**Expected behavior:**
- MRFT validation should FAIL because DMF-123 needs corresponding trailer
- Should NOT complain about missing [FOO-1.2.3] trailer (correctly ignored)
- Should be satisfied with BUG456 trailer

**Current trailers:**
Fixes: BUG456